### PR TITLE
Bring back 'Component#after_render'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - `inject` class method for `Component`
 - `init` callbacks
+- `Component#on_mounted` callback added. Triggers when the component has been mounted to the DOM.
 
 ### Removed
 - `router` - moved to separate gem

--- a/opal/inesita/component.rb
+++ b/opal/inesita/component.rb
@@ -18,7 +18,16 @@ module Inesita
       @virtual_dom = render_virtual_dom
       @root_node = VirtualDOM.create(@virtual_dom)
       Browser.append_child(element, @root_node)
+      @root_component.call_on_mounted
       self
+    end
+
+    def add_on_mounted_callback(block)
+      @on_mounted_callbacks << block
+    end
+
+    def call_on_mounted
+      @on_mounted_callbacks.reverse_each(&:call)
     end
 
     attr_reader :props

--- a/opal/inesita/component/render.rb
+++ b/opal/inesita/component/render.rb
@@ -17,6 +17,8 @@ module Inesita
 
       def render_virtual_dom
         before_render
+        @on_mounted_callbacks = []
+        @root_component.add_on_mounted_callback(method(:on_mounted)) if respond_to?(:on_mounted)
         @cache_component_counter = 0
         @__virtual_nodes__ = []
         render

--- a/opal/inesita/injection.rb
+++ b/opal/inesita/injection.rb
@@ -37,6 +37,7 @@ module Inesita
     def render!
       Browser.animation_frame do
         @root_component.render_if_root
+        @root_component.call_on_mounted
       end
     end
   end


### PR DESCRIPTION
This component method callback is useful for JQuery plugins that change the real DOM and need the virtual DOM render to be patched before activating.

Example:
```ruby
def before_render
  Element['#outline'].nestable('destroy')
end

def after_render
  Element['#outline'].nestable({ ... options ...}.to_n)
end

def render
  div id: "outline"
end
```