### PR TITLE
Add should_render? lifecycle hook to components along with prev_props attribute

### DIFF
--- a/opal/inesita/component.rb
+++ b/opal/inesita/component.rb
@@ -21,8 +21,9 @@ module Inesita
       self
     end
 
-    attr_reader :props
+    attr_reader :props, :prev_props
     def with_props(props)
+      @prev_props = @props
       @props = props
       self
     end

--- a/opal/inesita/component/render.rb
+++ b/opal/inesita/component/render.rb
@@ -13,14 +13,16 @@ module Inesita
         @virtual_dom = new_virtual_dom
       end
 
+      def should_render?; true; end;
       def before_render; end;
 
       def render_virtual_dom
+        return @__virtual_nodes__ unless should_render?
         before_render
         @cache_component_counter = 0
         @__virtual_nodes__ = []
         render
-        to_vnode
+        to_vnode # Defined in opal-virtual-dom and takes @__virtual_nodes__
       end
     end
   end


### PR DESCRIPTION
The should_render? method is called before #before_render. A response of 'true' indicates the component should render, and 'false' indicates that changes to props or state have no impact on the results and that the previous render results can be used. If should_render? returns false, before_render and render methods are not called. Default behavior is to always render the component if you do not define this method.

This can drastically decrease render times for apps with hundreds or thousands of components on the page in a nested structure.

For convenience, Inesita provides you access to the props from the previous render in 'prev_props'. This allows you to do something as simple as this to say if the props are the same as the last render then there's no need to render this component again:

```ruby
class ExampleComponent
  include Inesita::Component

  def should_render?
    props != prev_props
  end

  def before_render
    . . .

  def render
    . . .
end
```

Of course, you can use any logic relevant to your app to determine whether the component should be rendered. For example, using a memoized version state from your store.

GOTCHA: child components that are nested will not be asked if they should render if the parent component says that it shouldn't render. For example, say you have ComponentA and within that component's render method you call ComponentB, and from ComponentB you call ComponentC. Say you also define should_render? in ComponentA and return 'false'. In this scenario, ComponentB and ComponentC will not be asked if they should render. The previous render results from all three components will be reused. This is a boon for deeply nested components since there's no overhead checking for dirty trees, but on the other hand, if you have a nested child underneath a memoized parent that does need to render, you are responsible for implementing your own dirty checking through the component tree to allow the child component to render.