### PR TITLE
Enabled the experimental ES6 syntax support

### DIFF
--- a/lib/inesita/minify.rb
+++ b/lib/inesita/minify.rb
@@ -12,7 +12,7 @@ module Inesita
 
     def js(source)
       if defined?(Uglifier)
-        Uglifier.compile(source)
+        Uglifier.compile(source, harmony: true)
       else
         source
       end


### PR DESCRIPTION
When using Uglifier with ES6 syntax without any options, an error will be thrown.
Uglifier::Error: Unexpected token: punc ((). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).