### PR TITLE
Bump version of opal-sprockets cause there is and error with Tild tem…

### DIFF
--- a/inesita.gemspec
+++ b/inesita.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'inesita'
-  s.version     = '0.9.1'
+  s.version     = '0.9.2'
   s.authors     = ['Michał Kalbarczyk']
   s.email       = 'fazibear@gmail.com'
   s.homepage    = 'http://github.com/inesita-rb/inesita'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'opal', '~> 1.0'
-  s.add_dependency 'opal-sprockets', '~> 0'
+  s.add_dependency 'opal-sprockets', '~> 0.4.9'
   s.add_dependency 'opal-virtual-dom', '~> 0.6.1'
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'rack-rewrite', '~> 1.5'

--- a/inesita.gemspec
+++ b/inesita.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'opal', '~> 1.0'
-  s.add_dependency 'opal-sprockets', '~> 0.4.9'
+  s.add_dependency 'opal-sprockets', '> 0.3'
   s.add_dependency 'opal-virtual-dom', '~> 0.6.1'
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'rack-rewrite', '~> 1.5'

--- a/inesita.gemspec
+++ b/inesita.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'inesita'
-  s.version     = '0.9.2'
+  s.version     = '0.9.1'
   s.authors     = ['Michał Kalbarczyk']
   s.email       = 'fazibear@gmail.com'
   s.homepage    = 'http://github.com/inesita-rb/inesita'


### PR DESCRIPTION
Hello i was trying inesita and there was error with opal-sprockets it was looking for Tilt 

         1: from /home/georgi/.rvm/gems/ruby-2.7.0/gems/opal-sprockets-0.0.1/lib/opal/sprockets/processor.rb:4:in `<top (required)>'
/home/georgi/.rvm/gems/ruby-2.7.0/gems/opal-sprockets-0.0.1/lib/opal/sprockets/processor.rb:15:in `<module:Opal>': uninitialized constant Opal::Tilt (NameError)

so this is fixing this issue 